### PR TITLE
fix: configure next.js for github pages deployment

### DIFF
--- a/visual-algo/next.config.ts
+++ b/visual-algo/next.config.ts
@@ -4,6 +4,8 @@ const nextConfig: NextConfig = {
   /* config options here */
   output: "export",
   distDir: "dist",
+  basePath: "/visual-algo",
+  assetPrefix: "/visual-algo/",
 };
 
 export default nextConfig;


### PR DESCRIPTION
Adds the `basePath` and `assetPrefix` to the next.config.ts file to ensure that the application's assets are loaded correctly when deployed to GitHub Pages.