### PR TITLE
fix: configure next.js for github pages deployment

### DIFF
--- a/visual-algo/next.config.ts
+++ b/visual-algo/next.config.ts
@@ -4,6 +4,8 @@ const nextConfig: NextConfig = {
   /* config options here */
   output: "export",
   distDir: "dist",
+  basePath: "/visualizers",
+  assetPrefix: "/visualizers/",
 };
 
 export default nextConfig;

--- a/visual-algo/package.json
+++ b/visual-algo/package.json
@@ -2,6 +2,7 @@
   "name": "visual-algo",
   "version": "0.1.0",
   "private": true,
+  "homepage": "https://billharrisdev.github.io/visualizers",
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
I've updated the Next.js configuration to use the correct repository name (`visualizers`) for the `basePath` and `assetPrefix`. This is necessary for the application's assets to be loaded correctly when deployed to GitHub Pages.

I also added the `homepage` property to `package.json` as you requested.