### PR TITLE
fix: configure next.js for github pages deployment

### DIFF
--- a/visual-algo/next.config.ts
+++ b/visual-algo/next.config.ts
@@ -4,6 +4,7 @@ const nextConfig: NextConfig = {
   /* config options here */
   output: "export",
   distDir: "dist",
+  basePath: "/visualizers",
 };
 
 export default nextConfig;

--- a/visual-algo/package.json
+++ b/visual-algo/package.json
@@ -2,6 +2,7 @@
   "name": "visual-algo",
   "version": "0.1.0",
   "private": true,
+  "homepage": "https://billharrisdev.github.io/visualizers",
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
Removes the `assetPrefix` from the Next.js configuration. The `basePath` should be sufficient for deploying to a subpath on GitHub Pages, and the explicit `assetPrefix` may have been causing issues.

This commit builds on the previous changes to set the correct `basePath` and add the `homepage` property to `package.json`.