### PR TITLE
feat(visualizer): Refactor bubble sort with Framer Motion

### DIFF
--- a/jules-scratch/verification/verify_framer_motion.py
+++ b/jules-scratch/verification/verify_framer_motion.py
@@ -1,0 +1,35 @@
+import re
+from playwright.sync_api import sync_playwright, expect
+
+def run(playwright):
+    browser = playwright.chromium.launch()
+    page = browser.new_page()
+
+    # Navigate to the bubble sort page.
+    page.goto("http://localhost:3000/sort/bubble")
+
+    # Wait for the page heading to be visible to ensure the page loaded.
+    heading = page.get_by_role("heading", name="Bubble Sort")
+    expect(heading).to_be_visible(timeout=10000)
+
+    # Find the "Start Bubble Sort" button and click it.
+    start_button = page.get_by_role("button", name="Start Bubble Sort")
+    expect(start_button).to_be_enabled()
+    start_button.click()
+
+    # Expect the button to become disabled after clicking
+    expect(start_button).to_be_disabled()
+
+    # Wait for the animation to progress by looking for a green bar.
+    # A green bar indicates that at least one pass of the sort is complete.
+    # The color is now set via style prop, so we need to use a different selector.
+    green_bar_locator = page.locator('div[style*="background-color: rgb(34, 197, 94)"]')
+    expect(green_bar_locator).to_be_visible(timeout=10000)
+
+    # Take a screenshot
+    page.screenshot(path="jules-scratch/verification/framer_motion_working.png")
+
+    browser.close()
+
+with sync_playwright() as playwright:
+    run(playwright)

--- a/visual-algo/package-lock.json
+++ b/visual-algo/package-lock.json
@@ -11,6 +11,7 @@
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-slot": "^1.2.3",
         "class-variance-authority": "^0.7.1",
+        "framer-motion": "^11.3.19",
         "next": "15.4.6",
         "react": "19.1.0",
         "react-dom": "19.1.0",
@@ -5653,6 +5654,33 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "11.18.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
+      "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^11.18.1",
+        "motion-utils": "^11.18.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -8410,6 +8438,21 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
+      "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^11.18.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
+      "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/visual-algo/package.json
+++ b/visual-algo/package.json
@@ -14,6 +14,7 @@
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-slot": "^1.2.3",
     "class-variance-authority": "^0.7.1",
+    "framer-motion": "^11.3.19",
     "next": "15.4.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",


### PR DESCRIPTION
I've refactored the bubble sort visualizer to use the `framer-motion` library for animations, replacing the manual, brittle `setTimeout` and state update logic.

The previous implementation failed to animate correctly. This new approach is more robust and should provide you with a smoother, more polished experience.

The new logic works by:
1. Pre-calculating all the steps of the bubble sort algorithm (comparisons and swaps).
2. Storing these steps in an array in the component's state.
3. Using a `useEffect` hook with a timer to iterate through the steps.
4. Rendering the visualization with `motion.div` components, allowing Framer Motion to handle the animation of height and color changes automatically.