### PR TITLE
chore(visualizer): Address lint error

### DIFF
--- a/visual-algo/src/components/visualizers/bubble-sort-visualizer.tsx
+++ b/visual-algo/src/components/visualizers/bubble-sort-visualizer.tsx
@@ -39,7 +39,7 @@ export default function BubbleSortVisualizer() {
   const bubbleSort = () => {
     const arr = [...array];
     const steps: AnimationStep[] = [];
-    let sorted: number[] = [];
+    const sorted: number[] = [];
 
     for (let i = 0; i < arr.length - 1; i++) {
       for (let j = 0; j < arr.length - i - 1; j++) {


### PR DESCRIPTION
Changes `let` to `const` for the `sorted` array variable, as it is never reassigned. This resolves a linting error.