### PR TITLE
fix(visualizer): Correct rendering with stable keys and widths

### DIFF
--- a/visual-algo/src/components/visualizers/bubble-sort-visualizer.tsx
+++ b/visual-algo/src/components/visualizers/bubble-sort-visualizer.tsx
@@ -7,25 +7,33 @@ import { Button } from "@/components/ui/button"
 const ARRAY_SIZE = 50;
 const MIN_VALUE = 5;
 const MAX_VALUE = 100;
-const ANIMATION_SPEED_MS = 50; // Slower for better visualization
+const ANIMATION_SPEED_MS = 50;
+
+type Bar = {
+  id: number;
+  value: number;
+};
 
 type AnimationStep = {
-  array: number[];
+  array: Bar[];
   comparing: number[];
   sorted: number[];
 }
 
 export default function BubbleSortVisualizer() {
-  const [array, setArray] = useState<number[]>([]);
+  const [array, setArray] = useState<Bar[]>([]);
   const [animationSteps, setAnimationSteps] = useState<AnimationStep[]>([]);
   const [currentStep, setCurrentStep] = useState(0);
   const [isSorting, setIsSorting] = useState(false);
 
   const generateArray = useCallback(() => {
     if (isSorting) return;
-    const newArray = [];
+    const newArray: Bar[] = [];
     for (let i = 0; i < ARRAY_SIZE; i++) {
-      newArray.push(Math.floor(Math.random() * (MAX_VALUE - MIN_VALUE + 1)) + MIN_VALUE);
+      newArray.push({
+        id: i,
+        value: Math.floor(Math.random() * (MAX_VALUE - MIN_VALUE + 1)) + MIN_VALUE,
+      });
     }
     setArray(newArray);
     setAnimationSteps([]);
@@ -37,36 +45,34 @@ export default function BubbleSortVisualizer() {
   }, [generateArray]);
 
   const bubbleSort = () => {
-    const arr = [...array];
+    // Create a deep copy to avoid mutation issues
+    const arr = JSON.parse(JSON.stringify(array));
     const steps: AnimationStep[] = [];
     const sorted: number[] = [];
 
     for (let i = 0; i < arr.length - 1; i++) {
       for (let j = 0; j < arr.length - i - 1; j++) {
-        // Step to show comparison
         steps.push({
-          array: [...arr],
-          comparing: [j, j + 1],
+          array: JSON.parse(JSON.stringify(arr)),
+          comparing: [arr[j].id, arr[j + 1].id],
           sorted: [...sorted],
         });
 
-        if (arr[j] > arr[j + 1]) {
+        if (arr[j].value > arr[j + 1].value) {
           [arr[j], arr[j + 1]] = [arr[j + 1], arr[j]];
-          // Step to show the swap
           steps.push({
-            array: [...arr],
-            comparing: [j, j + 1],
+            array: JSON.parse(JSON.stringify(arr)),
+            comparing: [arr[j].id, arr[j + 1].id],
             sorted: [...sorted],
           });
         }
       }
-      sorted.push(arr.length - 1 - i);
+      sorted.push(arr[arr.length - 1 - i].id);
     }
-    sorted.push(0); // The last element is also sorted
+    sorted.push(arr[0].id);
 
-    // Final step to show all sorted
     steps.push({
-      array: [...arr],
+      array: JSON.parse(JSON.stringify(arr)),
       comparing: [],
       sorted: [...sorted],
     });
@@ -77,30 +83,24 @@ export default function BubbleSortVisualizer() {
 
   useEffect(() => {
     if (!isSorting) return;
-
     if (currentStep >= animationSteps.length - 1) {
       setIsSorting(false);
       return;
     }
-
     const timer = setTimeout(() => {
       setCurrentStep(currentStep + 1);
     }, ANIMATION_SPEED_MS);
-
     return () => clearTimeout(timer);
   }, [currentStep, isSorting, animationSteps]);
 
-  const currentArray = animationSteps[currentStep]?.array || array;
-  const comparingIndices = animationSteps[currentStep]?.comparing || [];
-  const sortedIndices = animationSteps[currentStep]?.sorted || [];
+  const currentFrame = animationSteps[currentStep];
+  const currentArray = currentFrame?.array || array;
+  const comparingIds = currentFrame?.comparing || [];
+  const sortedIds = currentFrame?.sorted || [];
 
-  const getBarColor = (index: number) => {
-    if (sortedIndices.includes(index)) {
-      return "#22c55e"; // green-500
-    }
-    if (comparingIndices.includes(index)) {
-      return "#ef4444"; // red-500
-    }
+  const getBarColor = (id: number) => {
+    if (sortedIds.includes(id)) return "#22c55e"; // green-500
+    if (comparingIds.includes(id)) return "#ef4444"; // red-500
     return "#3b82f6"; // blue-500
   };
 
@@ -108,17 +108,17 @@ export default function BubbleSortVisualizer() {
     <div className="w-full">
       <div className="flex justify-center items-end h-96 border border-gray-200 rounded-lg p-4 bg-gray-50 gap-px">
         <AnimatePresence>
-          {currentArray.map((value, idx) => (
+          {currentArray.map((item) => (
             <motion.div
-              key={idx}
+              key={item.id}
               layout
               initial={{ height: 0 }}
               animate={{
-                height: `${value}%`,
-                backgroundColor: getBarColor(idx),
+                height: `${item.value}%`,
+                backgroundColor: getBarColor(item.id),
               }}
               transition={{ duration: 0.3 }}
-              className="flex-grow"
+              style={{ width: `calc(100% / ${ARRAY_SIZE})` }}
             />
           ))}
         </AnimatePresence>


### PR DESCRIPTION
This commit fixes a persistent bug where the bubble sort animation was not visible. The root cause was identified in the rendering logic.

The changes are:
1.  The data structure for the array has been changed from an array of numbers to an array of objects, each with a stable `id` and a `value`.
2.  The `key` prop for each bar in the visualizer now uses this stable `id`, which is crucial for React and Framer Motion to correctly track and animate elements that change order.
3.  An explicit `width` is now calculated and applied to each bar, preventing them from collapsing to zero width.

These changes ensure that the bars are rendered correctly and that their animations are tracked properly, which should resolve the visualization bug.